### PR TITLE
0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ sudo reboot
 ---
 ---
 ## CHANGELOG:
+### Version 0.3.1
+- Improved playlists
+    - Better playlist display (`/playlist list` or `!playlist`)
+        - Can now display the whole playlist (with pages)
+        - Can now shuffle the playlist before loading into queue
+        - Can now load into queue straight form this embed
+    - Can now load a YouTube playlist into your custom playlist all at once! just use `/playlist add <playlist_name / index> <playlist url>`
+- Improved Queue
+    - Better queue display
+        - Can now see the whole queue on pages of 20
+        - Can shuffle the queue
+        - `/queue` or `!queue`
+    - Can load a whole YouTube playlist into the queue!
+        - Just use `/play <playlist url>` or `!play <playlist_url>?`
 ### Version 0.3
 - **Music player now supports most sources (excluding Spotify)**
 - **Added Playlists - you can now create custom playlists, that can be loaded at any time into the queue**

--- a/cogs/_player.py
+++ b/cogs/_player.py
@@ -101,10 +101,14 @@ class _Player(commands.Cog):
         ctx = await self.bot.get_context(interaction)
         try:
 
-            if query is None:
-                info = musicplayer.get_info(Queues.next_song(ctx.guild.id)['url'])
-            else:
-                info = musicplayer.get_info(query)
+            info = None
+            while info is None:
+                if query is None:
+                    info = musicplayer.get_info(Queues.next_song(ctx.guild.id)['url'])
+                else:
+                    info = musicplayer.get_info(query)
+                if info is None:
+                    info = musicplayer.get_info(Queues.next_song(ctx.guild.id)['url'])
             video_url = info['url']
             if is_windows:
                 audio_source = discord.FFmpegPCMAudio(video_url,executable=config.FFMPEG_PATH,**config.ffmpeg_options)

--- a/cogs/player.py
+++ b/cogs/player.py
@@ -122,12 +122,17 @@ class Player(commands.Cog):
                     return
                 except TypeError:
                     pass
-            if query is None:
-                info = musicplayer.get_info(Queues.next_song(ctx.guild.id)['url'])
-            else:
-                info = musicplayer.get_info(query)
+            info = None
+            while info is None:
+                if query is None:
+                    info = musicplayer.get_info(Queues.next_song(ctx.guild.id)['url'])
+                else:
+                    info = musicplayer.get_info(query)
+                if info is None:
+                    info = musicplayer.get_info(Queues.next_song(ctx.guild.id)['url'])
             ctx.bot.video_info = info
             ctx.bot.video_url = info['url']
+            
             if is_windows:
                 audio_source = discord.FFmpegPCMAudio(info['url'], executable=config.FFMPEG_PATH, **config.ffmpeg_options)
             else:

--- a/cogs/playlists.py
+++ b/cogs/playlists.py
@@ -58,7 +58,7 @@ class Playlist(commands.Cog):
                             await message.edit(embed=embed)
                             await message.remove_reaction(reaction.emoji, user)
                         except asyncio.TimeoutError:
-                            break
+                            pass
                             
                         except asyncio.TimeoutError:
                             break

--- a/utils/musicplayer.py
+++ b/utils/musicplayer.py
@@ -23,9 +23,12 @@ def extract_music_info(query:str):
             else:
                 info = ydl.extract_info(query, download=False)['entries'][0]
             return info
+    except yt_dlp.DownloadError as e:
+        print(f"[-] An error occurred while downloading the video: {e}") 
+        return None
     except Exception as e:
         print(f"[-] An error occurred while extracting info: {e}")
-        return None
+
     
 
 def extract_soundcloud_info(query:str):


### PR DESCRIPTION
# 0.3.1 release
- Improved playlists
    - Better playlist display (`/playlist list` or `!playlist`)
        - Can now display the whole playlist (with pages)
        - Can now shuffle the playlist before loading into queue
        - Can now load into queue straight form this embed
    - Can now load a YouTube playlist into your custom playlist all at once! just use `/playlist add <playlist_name / index> <playlist url>`
- Improved Queue
    - Better queue display
        - Can now see the whole queue on pages of 20
        - Can shuffle the queue
        - `/queue` or `!queue`
    - Can load a whole YouTube playlist into the queue!
        - Just use `/play <playlist url>` or `!play <playlist_url>?`
- Bug fixes:
    - Fixed queue breaking on attempting to load a deleted/unavailable song
    - Fixed pagination on Queues/Playlists
    - Fixed updater breaking on empty commit message
    - Fixed playlist load using slash command