### PR TITLE
Pic changer COG small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ sudo reboot
 
 ---
 ---
-
+### Version 0.3.4
+- Small improvements to picchanger cog:
+  - Fixed !banner command
+  - Added default avatar
+  - Improved URL parsing, added "none" or "default" options.
+    - **NOTE:** On startup, if the bot detects no avatar, it will automatically update to the default one!
 ### Version 0.3.3
 - HOTFIX:
   - Fixed configs Linux systems being unable to play music

--- a/cogs/picchanger.py
+++ b/cogs/picchanger.py
@@ -3,6 +3,7 @@ import base64
 import discord
 from discord.ext import commands
 from config import config
+import os
 
 
 class PicChanger(commands.Cog):
@@ -13,7 +14,7 @@ class PicChanger(commands.Cog):
     @commands.is_owner()
     async def banner(self, ctx, url:str = None):
         if not ctx.message.attachments and not url:
-            await ctx.send("Please attach an image or provide an URL to change the bot's banner")
+            await ctx.send(":information_source: Please attach an image or provide an URL to change the bot's banner\n- If you pass an URL as argument and it doesn't work, try attaching the image file to your message instead.")
             return
         if ctx.message.attachments:
             url = ctx.message.attachments[0].url
@@ -22,7 +23,7 @@ class PicChanger(commands.Cog):
             encoded_image = base64.b64encode(image.content).decode("utf-8")
 
             headers = {
-                "Authorization": f"Bot {config.bot_token}",
+                "Authorization": f"Bot {config.bot_token.strip()}",
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0",
                 "Content-Type": "application/json"
             }
@@ -33,7 +34,7 @@ class PicChanger(commands.Cog):
 
             response = requests.patch(url, headers=headers, json=data)
             if response.status_code != 200:
-                ctx.send(f"An error occurred: {response.json()}")
+                await ctx.send(f"An error occurred: {response.json()}")
                 return
 
             await ctx.send(":white_check_mark: Banner changed successfully!")
@@ -44,12 +45,31 @@ class PicChanger(commands.Cog):
     @commands.is_owner()
     async def avatar(self, ctx, url:str = None):
 
-        if not ctx.message.attachments and not url:
-            await ctx.send("Please attach an image or provide an URL to change the bot's avatar")
+        if ctx.message.content.split(" ")[1]:
+            url = ctx.message.content.split(" ")[1]
+            if "http" not in url and url != "none" and url != "default":
+                await ctx.send(":information_source: Please provide a valid URL or write \"none\" to remove the avatar, or write \"default\" to use the default avatar.")
+                return
+        elif ctx.message.attachments:
+            url = ctx.message.attachments[0].url
+        
+        print(url)
+
+        if url == "none":
+            await self.bot.user.edit(avatar=None)
+            await ctx.send(":white_check_mark: Avatar removed successfully!")
             return
         
-        if ctx.message.attachments:
-            url = ctx.message.attachments[0].url
+        if url == "default":
+            with open(os.path.join(config.config_path, "default.gif"), "rb") as image_file:
+                image = image_file.read()
+            await ctx.bot.user.edit(avatar=image)
+            await ctx.send(":white_check_mark: Avatar changed to default successfully!")
+            return
+    
+        if not url:
+            await ctx.send(":information_source: Please attach an image or provide an URL to change the bot's avatar, or write \"none\" to remove it. \nIf you want to use the default avatar, write \"default\".")
+            return
 
         try:                
             image = requests.get(url)
@@ -60,7 +80,16 @@ class PicChanger(commands.Cog):
             await ctx.send(f"An error occurred: {e}")
 
 async def setup(bot):
+    try:
+        if not bot.user.avatar:
+            print("[-] Bot avatar not found. Setting default avatar...")
+            with open(os.path.join(config.config_path, "default.gif"), "rb") as image_file:
+                image = image_file.read()
+            await bot.user.edit(avatar=image)
+    except Exception as e:
+        print(f"An error occurred while setting the default avatar: {e}")
     await bot.add_cog(PicChanger(bot))
+
 
 
     

--- a/config/config.py
+++ b/config/config.py
@@ -5,15 +5,15 @@ import os
 
 ### CONFIGURATION FILES
 #get the full path for the current folder
-current_folder = os.path.dirname(os.path.abspath(__file__))
-serversettings = os.path.join(current_folder, 'serversettings.json')
-queues = os.path.join(current_folder, 'queues.json')
-token_file = os.path.join(current_folder, 'bot_token.txt')
-playlists_folder = os.path.join(os.path.dirname(current_folder), 'playlists')
+config_path = os.path.dirname(os.path.abspath(__file__))
+serversettings = os.path.join(config_path, 'serversettings.json')
+queues = os.path.join(config_path, 'queues.json')
+token_file = os.path.join(config_path, 'bot_token.txt')
+playlists_folder = os.path.join(os.path.dirname(config_path), 'playlists')
 FFMPEG_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'ffmpeg.exe')
 bot_token=''
-cogs_dir = os.path.join(os.path.dirname(current_folder), 'cogs')
-cache_dir = os.path.join(os.path.dirname(current_folder), 'cache')
+cogs_dir = os.path.join(os.path.dirname(config_path), 'cogs')
+cache_dir = os.path.join(os.path.dirname(config_path), 'cache')
 cookies_file = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'cookies.txt')
 
 


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the `picchanger` cog, as well as some configuration updates. The most important changes include enhancements to the `avatar` and `banner` commands, setting a default avatar on startup, and refining the configuration paths.

Enhancements to `picchanger` cog:

* [`cogs/picchanger.py`](diffhunk://#diff-a8deace96d366b8fa3ca8ebcfd13fbae755a633c356d51d6bc390693619c832eL16-R17): Improved the `banner` command to provide more detailed instructions when an invalid URL is provided and fixed the authorization header to strip any extra spaces. 
* [`cogs/picchanger.py`](diffhunk://#diff-a8deace96d366b8fa3ca8ebcfd13fbae755a633c356d51d6bc390693619c832eL47-R73): Enhanced the `avatar` command to support "none" or "default" options, and added logic to handle these options appropriately, including setting a default avatar on startup if none is found. 

Configuration updates:

* `config/config.py`: Updated the configuration paths to use a more consistent `config_path` variable.
